### PR TITLE
[BUGFIX] Don't Get Cached Value From Redis for Non-GET Methods

### DIFF
--- a/index.js
+++ b/index.js
@@ -71,7 +71,7 @@ module.exports = function(options = {}) {
       }
     }
 
-    if (!redisAvailable || !match || (passParam && ctx.request.query[passParam])) {
+    if (!redisAvailable || !match || (passParam && ctx.request.query[passParam]) || (ctx.request.method !== 'GET')) {
       return await next()
     }
 

--- a/test/koa-redis-cache.js
+++ b/test/koa-redis-cache.js
@@ -38,6 +38,15 @@ describe('## default options', () => {
     if (ctx.path === '/app/500') {
       ctx.status = 500
       ctx.body = 'no cache'
+      return
+    }
+    if (ctx.path === '/app/something' && ctx.method === 'GET') {
+      ctx.body = 'GET response'
+      return
+    }
+    if (ctx.path === '/app/something' && ctx.method === 'PUT') {
+      ctx.body = 'PUT response'
+      return
     }
   })
 
@@ -268,6 +277,29 @@ describe('## default options', () => {
           should.not.exist(res.headers['x-koa-redis-cache'])
           equal(res.text, 'no cache')
           done()
+        })
+    })
+  })
+
+  describe('# not GET, no cache', () => {
+    it('no cache for PUT even after GET', (done) => {
+      request(app)
+        .get('/app/something')
+        .end((getErr, getRes) => {
+          should.not.exist(getErr)
+          getRes.headers['content-type'].should.equal('text/plain; charset=utf-8')
+          should.not.exist(getRes.headers['x-koa-redis-cache'])
+          equal(getRes.text, 'GET response')
+
+          request(app)
+            .put('/app/something')
+            .end((putErr, putRes) => {
+              should.not.exist(putErr)
+              putRes.headers['content-type'].should.equal('text/plain; charset=utf-8')
+              should.not.exist(putRes.headers['x-koa-redis-cache'])
+              equal(putRes.text, 'PUT response')
+              done()
+            })
         })
     })
   })


### PR DESCRIPTION
### Issue

As an user, I receive wrong data on POST/PUT/etc requests, if before that I call GET method with same url

### Reproduction steps

0. Prerequirements. You need to have at least two endpoints with same URL (assume GET and PUT)
1. call PUT - everything ok (there's no X-Koa-redis-cache header) - ✅ 
2. call GET - everything ok (there's no X-Koa-redis-cache header) - ✅ 
3. Optional. call GET - everything ok (there is X-Koa-redis-cache header) - ✅ 
4. call PUT - I receive body from previous GET request (there is X-Koa-redis-cache header) - ⚠️ 

### How To Fix

Check HTTP method before reading from cache
